### PR TITLE
Remove Port.Conservative, be more selective for evar bounds

### DIFF
--- a/pyomo/network/tests/test_arc.py
+++ b/pyomo/network/tests/test_arc.py
@@ -984,14 +984,14 @@ class TestArc(unittest.TestCase):
     1 Declarations: v_equality
 """)
 
-    def test_conservative_single_var(self):
+    def test_extensive_no_splitfrac_single_var(self):
         m = ConcreteModel()
         m.x = Var()
         m.y = Var()
         m.z = Var()
-        m.p1 = Port(initialize={'v': (m.x, Port.Conservative)})
-        m.p2 = Port(initialize={'v': (m.y, Port.Conservative)})
-        m.p3 = Port(initialize={'v': (m.z, Port.Conservative)})
+        m.p1 = Port(initialize={'v': (m.x, Port.Extensive, {'include_splitfrac':False})})
+        m.p2 = Port(initialize={'v': (m.y, Port.Extensive, {'include_splitfrac':False})})
+        m.p3 = Port(initialize={'v': (m.z, Port.Extensive, {'include_splitfrac':False})})
         m.a1 = Arc(source=m.p1, destination=m.p2)
         m.a2 = Arc(source=m.p1, destination=m.p3)
 
@@ -1136,7 +1136,7 @@ class TestArc(unittest.TestCase):
 13 Declarations: x y z p1 p2 p3 a1 a2 a1_expanded a2_expanded p1_v_outsum p2_v_insum p3_v_insum
 """)
 
-    def test_conservative_expansion(self):
+    def test_extensive_no_splitfrac_expansion(self):
         m = ConcreteModel()
         m.time = Set(initialize=[1, 2, 3])
 
@@ -1147,12 +1147,12 @@ class TestArc(unittest.TestCase):
         def source_block(b):
             b.t = Set(initialize=[1, 2, 3])
             b.p_out = Var(b.t)
-            b.outlet = Port(initialize={'p': (b.p_out, Port.Conservative)})
+            b.outlet = Port(initialize={'p': (b.p_out, Port.Extensive, {'include_splitfrac':False})})
 
         def load_block(b):
             b.t = Set(initialize=[1, 2, 3])
             b.p_in = Var(b.t)
-            b.inlet = Port(initialize={'p': (b.p_in, Port.Conservative)})
+            b.inlet = Port(initialize={'p': (b.p_in, Port.Extensive, {'include_splitfrac':False})})
 
         source_block(m.source)
         load_block(m.load1)
@@ -1530,9 +1530,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1558,9 +1558,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1586,9 +1586,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1614,9 +1614,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :     0 :  None :  None : False :  True :  Reals
+                  b :     0 :  None :  None : False :  True :  Reals
+                  c :     0 :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1657,9 +1657,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1685,9 +1685,9 @@ class TestArc(unittest.TestCase):
         2 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :     0 :  None :  None : False :  True :  Reals
+                  b :     0 :  None :  None : False :  True :  Reals
+                  c :     0 :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1702,9 +1702,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1730,9 +1730,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
@@ -1758,9 +1758,9 @@ class TestArc(unittest.TestCase):
         3 Var Declarations
             flow : Size=3, Index=comp
                 Key : Lower : Value : Upper : Fixed : Stale : Domain
-                  a :     0 :  None :  None : False :  True : NonNegativeReals
-                  b :     0 :  None :  None : False :  True : NonNegativeReals
-                  c :     0 :  None :  None : False :  True : NonNegativeReals
+                  a :  None :  None :  None : False :  True :  Reals
+                  b :  None :  None :  None : False :  True :  Reals
+                  c :  None :  None :  None : False :  True :  Reals
             mass : Size=1, Index=None
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals

--- a/pyomo/network/util.py
+++ b/pyomo/network/util.py
@@ -11,6 +11,56 @@
 from pyomo.core import Var
 from pyomo.core.base.indexed_component import UnindexedComponent_set
 
+def create_var(comp, name, block, index_set=None):
+    if index_set is None:
+        if comp.is_indexed():
+            index_set = comp.index_set()
+        else:
+            index_set = UnindexedComponent_set
+
+    new_var = Var(index_set)
+    block.add_component(name, new_var)
+    return new_var
+
+def _tighten(src, dest):
+    starting_lb = dest.lb
+    starting_ub = dest.ub
+    if not src.is_continuous():
+        dest.domain = src.domain
+    if src.lb is not None:
+        if starting_lb is None:
+            dest.setlb(src.lb)
+        else:
+            dest.setlb(max(starting_lb, src.lb))
+    if src.ub is not None:
+        if starting_ub is None:
+            dest.setub(src.ub)
+        else:
+            dest.setub(min(starting_ub, src.ub))
+
+def tighten_var_domain(comp, new_var, index_set=None):
+    if index_set is None:
+        if comp.is_indexed():
+            index_set = comp.index_set()
+        else:
+            index_set = UnindexedComponent_set
+
+    if comp.is_indexed():
+        for i in index_set:
+            try:
+                # set bounds for every member in case they differ
+                _tighten(comp[i], new_var[i])
+            except AttributeError:
+                break
+    else:
+        try:
+            # set bounds for every member in case they differ
+            _tighten(comp, new_var)
+        except AttributeError:
+            pass
+
+    return new_var
+
 def replicate_var(comp, name, block, index_set=None):
     """
     Create a new variable that will have the same indexing set, domain,
@@ -18,33 +68,6 @@ def replicate_var(comp, name, block, index_set=None):
     Optionally pass an index set to use that to build the variable, but
     this set must be symmetric to comp's index set.
     """
-    if index_set is None:
-        if comp.is_indexed():
-            index_set = comp.index_set()
-        else:
-            index_set = UnindexedComponent_set
-
-    var_args = {}
-    # try:
-    #     var_args['domain'] = comp.domain
-    # except AttributeError:
-    #     pass
-    # try:
-    #     var_args['bounds'] = comp.bounds
-    # except AttributeError:
-    #     pass
-
-    new_var = Var(index_set, **var_args)
-    block.add_component(name, new_var)
-    if comp.is_indexed():
-        for i in index_set:
-            try:
-                # set bounds for every member in case they differ
-                pass
-                # new_var[i].domain = comp[i].domain
-                # new_var[i].setlb(comp[i].lb)
-                # new_var[i].setub(comp[i].ub)
-            except AttributeError:
-                break
-
+    new_var = create_var(comp, name, block, index_set)
+    tighten_var_domain(comp, new_var, index_set)
     return new_var


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This removes the Conservative rule and its helper methods and instead changes the handling of `include_splitfrac` to that specifying `include_splitfrac=False` will prevent the split fraction variables from being created.  This also changes how expanded arc variables' domains and bounds are set, so that the domain is only tightened when the arc has a single source or single destination.

## Changes proposed in this PR:
- remove `Port.Conservative`
- make `Port.Extensive`'s `include_splitfrac=False` actually prevent the inclusion of split fractions
- restore some propagation of bounds / domain information from Ports to Arc variables.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
